### PR TITLE
Introduce table names magic and conventions.

### DIFF
--- a/autoload/dbext.vim
+++ b/autoload/dbext.vim
@@ -5448,6 +5448,9 @@ endfunction
 
 function! s:DB_applyTableNameConvention(word)
     let result = a:word
+    if g:dbext_table_names_strip_id == 1
+        let result = substitute(result, '_\?ids\?$', '', '')
+    endif
     if g:dbext_table_names_number == 1
             let result = s:singularize(result)
     elseif g:dbext_table_names_number == 2
@@ -5458,6 +5461,7 @@ function! s:DB_applyTableNameConvention(word)
     elseif g:dbext_table_names_case == 2
         let result = s:underscore(result)
     endif
+
     return result
 endfunction
     

--- a/autoload/dbext.vim
+++ b/autoload/dbext.vim
@@ -5396,6 +5396,10 @@ function! s:sub(str,pat,rep)
   return substitute(a:str,'\v\C'.a:pat,a:rep,'')
 endfunction
 
+function! s:gsub(str,pat,rep)
+  return substitute(a:str,'\v\C'.a:pat,a:rep,'g')
+endfunction
+
 function! s:singularize(word)
     " Probably not worth it to be not comprehensive but we can
     " still hit the common cases.
@@ -5428,13 +5432,33 @@ function! s:pluralize(word)
     return word
 endfunction
 
+function! s:underscore(str)
+  let str = s:gsub(a:str,'::','/')
+  let str = s:gsub(str,'(\u+)(\u\l)','\1_\2')
+  let str = s:gsub(str,'(\l|\d)(\u)','\1_\2')
+  let str = tolower(str)
+  return str
+endfunction
+
+function! s:camelize(str)
+  let str = s:gsub(a:str,'/(.=)','::\u\1')
+  let str = s:gsub(str,'%([_-]|<)(.)','\u\1')
+  return str
+endfunction
+
 function! s:DB_applyTableNameConvention(word)
-    if g:dbext_table_names_convention == 1
-            return s:singularize(a:word)
-    elseif g:dbext_table_names_convention == 2
-            return s:pluralize(a:word)
+    let result = a:word
+    if g:dbext_table_names_number == 1
+            let result = s:singularize(result)
+    elseif g:dbext_table_names_number == 2
+            let result =  s:pluralize(result)
     endif
-    return a:word
+    if g:dbext_table_names_case == 1
+        let result = s:camelize(result)
+    elseif g:dbext_table_names_case == 2
+        let result = s:underscore(result)
+    endif
+    return result
 endfunction
     
 

--- a/doc/dbext.txt
+++ b/doc/dbext.txt
@@ -1565,17 +1565,27 @@ Version 2.00
   underscore plural. By default dbext follow this convention.
 
   Example:
-    when the cursor is on "ProjectIndustry" >
-        :DBSelectFromTable  
+      when the cursor is on "ProjectIndustry" >
+          :DBSelectFromTable  
 <
-    will do:
-      "select * from project_industries"
-
+      will do: >
+          select * from project_industries
+<
+  dbext can automatically strip id suffix from the word under cursor to get 
+  valid table name from string. 
+  
+  Example: 
+      when the cursor is on "category_id" or "category_ids" >
+          :DBSelectFromTable
+<
+      will do: >
+          select * from categories
+<
   
   Table names number:
 
       To get control over table names number convention use: >
-        let g:dbext_table_names_number 
+          let g:dbext_table_names_number 
 < 
       Set to 0 if table names number should be as is
       Set to 1 if table names should be singularized
@@ -1592,9 +1602,12 @@ Version 2.00
       Set to 2 if table names should be underscored
 
       Default: 2
-    
-  
-    
+
+  Strip ids option:
+      To disable strip ids option use: >
+          let g:dbext_table_names_strip_id = 0
+<
+      Default: 1
 
 
 

--- a/doc/dbext.txt
+++ b/doc/dbext.txt
@@ -29,6 +29,7 @@ Homepage: http://vim.sourceforge.net/script.php?script_id=356
     5.3 Database Specific Options             |dbext-configure-options|
     5.4 DB2 Modes                             |dbext-configure-db2|
     5.5 DBI Installation                      |dbext-configure-dbi|
+    5.6 Table names convention                |dbext-table-names|
 6.  Mappings and commands		      |dbext-mappings|
 7.  Adding new database types		      |dbext-newdb|
 8.  Prompting for input parameters	      |dbext-prompting|
@@ -1477,7 +1478,7 @@ Version 2.00
 5.5 DBI Installation                                    *dbext-configure-dbi*
     To use the DBI interface you must first have a Perl enabled Vim.
     You can test your installation by running this command: >
-        :echo has('perl')
+       :echo has('perl')
 <
     If you Vim is not Perl enabled you can:
         1.  Compile your own Vim and enable it.  Tony Mechelynck has posted
@@ -1556,6 +1557,47 @@ Version 2.00
             install Sybase-TdsServer
             install DBD-mysql
             quit
+
+5.6 Table names convention                                 *dbext-table-names*
+  
+  Most application follow naming convention between Models and realted table.
+  In most cases models are named in camelcase singular and tables in
+  underscore plural. By default dbext follow this convention.
+
+  Example:
+    when the cursor is on "ProjectIndustry" >
+        :DBSelectFromTable  
+<
+    will do:
+      "select * from project_industries"
+
+  
+  Table names number:
+
+      To get control over table names number convention use: >
+        let g:dbext_table_names_number 
+< 
+      Set to 0 if table names number should be as is
+      Set to 1 if table names should be singularized
+      Set to 2 if table names should be pluralized
+
+      Default: 2
+    
+  Table names case:
+      To get control over table names case convention use: >
+          let g:dbext_table_names_case
+<
+      Set to 0 if table names case should be as is
+      Set to 1 if table names should be camelized
+      Set to 2 if table names should be underscored
+
+      Default: 2
+    
+  
+    
+
+
+
 
 ==============================================================================
 6. Mappings and commands				*dbext-mappings*

--- a/plugin/dbext.vim
+++ b/plugin/dbext.vim
@@ -49,8 +49,12 @@ if !exists('g:dbext_rows_affected')
     let g:dbext_rows_affected = 0
 endif
 
-if !exists('g:dbext_table_names_convention')
-    let g:dbext_table_names_convention = 2
+if !exists('g:dbext_table_names_number')
+    let g:dbext_table_names_number= 2
+endif
+
+if !exists('g:dbext_table_names_case')
+    let g:dbext_table_names_case = 2
 endif
 
 " Commands {{{

--- a/plugin/dbext.vim
+++ b/plugin/dbext.vim
@@ -49,6 +49,10 @@ if !exists('g:dbext_rows_affected')
     let g:dbext_rows_affected = 0
 endif
 
+if !exists('g:dbext_table_names_convention')
+    let g:dbext_table_names_convention = 2
+endif
+
 " Commands {{{
 command! -nargs=+ DBExecSQL         :call dbext#DB_execSql(<q-args>)
 command! -nargs=+ DBExecSQLTopX     :call dbext#DB_execSqlTopX(<q-args>)

--- a/plugin/dbext.vim
+++ b/plugin/dbext.vim
@@ -57,6 +57,11 @@ if !exists('g:dbext_table_names_case')
     let g:dbext_table_names_case = 2
 endif
 
+
+if !exists('g:dbext_table_names_strip_id')
+    let g:dbext_table_names_strip_id = 1
+endif
+
 " Commands {{{
 command! -nargs=+ DBExecSQL         :call dbext#DB_execSql(<q-args>)
 command! -nargs=+ DBExecSQLTopX     :call dbext#DB_execSqlTopX(<q-args>)


### PR DESCRIPTION
When dbext is used from the source code - there is a problem that usually class or variable mapped to the database table has different naming convention. This patch allows you to apply table names  convention to word under cursor before using it as table name in db query. For example, all of the following words under cursor will be converted into `user_roles` on `DBSelectFromTable`:

```
user_role UserRole user_role_id user_role_ids
```
