### PR TITLE
Update help documentation to remove duplicate tags

### DIFF
--- a/doc/dbext.txt
+++ b/doc/dbext.txt
@@ -3025,15 +3025,15 @@ To specify the type of database you connect to most often, you can place the
 
  Each project you work on may have different standards and naming 
  conventions.  This autocmd works by checking if you are opening
- a file somewhere under a directory called MyProjectDir.  If so, it sets
+ a file somewhere under a directory /srv/MyProjectDir.  If so, it sets
  dbext's current variable_def_regex for this buffer.  This |autocmd| can be
  added to your |.vimrc|: >
-        autocmd BufRead */MyProjectDir/* DBSetOption variable_def_regex=\<\(p_\|lv_\)\w\+\>
+        autocmd BufRead /srv/MyProjectDir/* DBSetOption variable_def_regex=\<\(p_\|lv_\)\w\+\>
 <
  Or if you simply wanted to extended the existing defaults, you can
  retrieve the existing setting using dbext's DB_listOption function and
  concatenate the new regex separated by a comma: >
-        autocmd BufRead */MyProjectDir/* DBSetOption variable_def_regex=,\<\(p_\|lv_\)\w\+\>
+        autocmd BufRead /srv/MyProjectDir/* DBSetOption variable_def_regex=,\<\(p_\|lv_\)\w\+\>
 <
         
 


### PR DESCRIPTION
Rename the example directory to /srv/MyProjectDir from _/MyProjectDir/_
which is interpreted as a tag in help files and causes problems with
tools like pathogen which regenerate the tags file on the fly
